### PR TITLE
Add FastAPI Jira-like API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# TrackOS API
+
+A simple Jira-like API using FastAPI, MySQL and Docker.
+
+## Development
+
+Create `.env` with your MySQL credentials:
+
+```
+MYSQL_USER=user
+MYSQL_PASSWORD=pass
+MYSQL_HOST=localhost
+MYSQL_PORT=3306
+MYSQL_DB=apidb
+SECRET_KEY=change_me
+```
+
+Build and run:
+
+```
+docker build -t trackos .
+docker run -p 8000:8000 --env-file .env trackos
+```
+
+The API exposes registration and login endpoints returning JWT tokens, and allows management of organizations and projects with basic roles.

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,17 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+MYSQL_USER = os.getenv("MYSQL_USER", "root")
+MYSQL_PASSWORD = os.getenv("MYSQL_PASSWORD", "password")
+MYSQL_HOST = os.getenv("MYSQL_HOST", "localhost")
+MYSQL_PORT = os.getenv("MYSQL_PORT", "3306")
+MYSQL_DB = os.getenv("MYSQL_DB", "apidb")
+
+SQLALCHEMY_DATABASE_URL = (
+    f"mysql+pymysql://{MYSQL_USER}:{MYSQL_PASSWORD}@{MYSQL_HOST}:{MYSQL_PORT}/{MYSQL_DB}"
+)
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,9 @@
+from fastapi import FastAPI
+from app.database import engine
+from app.models import Base
+from app.routes import api_router
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="TrackOS API")
+app.include_router(api_router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,5 @@
+from .user import User
+from .organization import Organization
+from .organization_user import OrganizationUser
+from .project import Project
+from .project_user import ProjectUser

--- a/app/models/organization.py
+++ b/app/models/organization.py
@@ -1,0 +1,12 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+from app.database import Base
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100), unique=True)
+
+    members = relationship("OrganizationUser", back_populates="organization")
+    projects = relationship("Project", back_populates="organization")

--- a/app/models/organization_user.py
+++ b/app/models/organization_user.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, ForeignKey, String
+from sqlalchemy.orm import relationship
+from app.database import Base
+
+class OrganizationUser(Base):
+    __tablename__ = "organization_users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    organization_id = Column(Integer, ForeignKey("organizations.id"))
+    role = Column(String(50), default="participant")
+
+    user = relationship("User", back_populates="organizations")
+    organization = relationship("Organization", back_populates="members")

--- a/app/models/project.py
+++ b/app/models/project.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, ForeignKey
+from sqlalchemy.orm import relationship
+from app.database import Base
+
+class Project(Base):
+    __tablename__ = "projects"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(100))
+    organization_id = Column(Integer, ForeignKey("organizations.id"))
+
+    organization = relationship("Organization", back_populates="projects")
+    members = relationship("ProjectUser", back_populates="project")

--- a/app/models/project_user.py
+++ b/app/models/project_user.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, ForeignKey, String
+from sqlalchemy.orm import relationship
+from app.database import Base
+
+class ProjectUser(Base):
+    __tablename__ = "project_users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"))
+    project_id = Column(Integer, ForeignKey("projects.id"))
+    role = Column(String(50), default="participant")
+
+    user = relationship("User", back_populates="projects")
+    project = relationship("Project", back_populates="members")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import relationship
+from app.database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(50), unique=True, index=True)
+    email = Column(String(100), unique=True, index=True)
+    hashed_password = Column(String(255))
+
+    organizations = relationship("OrganizationUser", back_populates="user")
+    projects = relationship("ProjectUser", back_populates="user")

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter
+from .auth import router as auth_router
+from .organization import router as org_router
+from .project import router as project_router
+
+api_router = APIRouter()
+api_router.include_router(auth_router)
+api_router.include_router(org_router)
+api_router.include_router(project_router)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from app.models import User
+from app.schemas import UserCreate, Token
+from app.utils.security import get_password_hash, verify_password, create_access_token
+from app.utils.deps import get_db
+
+router = APIRouter()
+
+@router.post("/register", response_model=Token)
+def register(user: UserCreate, db: Session = Depends(get_db)):
+    if db.query(User).filter(User.username == user.username).first():
+        raise HTTPException(status_code=400, detail="Username already registered")
+    db_user = User(username=user.username, email=user.email, hashed_password=get_password_hash(user.password))
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    token = create_access_token({"sub": str(db_user.id)})
+    return {"access_token": token}
+
+@router.post("/login", response_model=Token)
+def login(user: UserCreate, db: Session = Depends(get_db)):
+    db_user = db.query(User).filter(User.username == user.username).first()
+    if not db_user or not verify_password(user.password, db_user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    token = create_access_token({"sub": str(db_user.id)})
+    return {"access_token": token}

--- a/app/routes/organization.py
+++ b/app/routes/organization.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.models import Organization, OrganizationUser
+from app.schemas import OrganizationCreate, OrganizationRead
+from app.utils.deps import get_db, get_current_user
+
+router = APIRouter(prefix="/organizations")
+
+@router.post("/", response_model=OrganizationRead)
+def create_org(org: OrganizationCreate, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
+    if db.query(Organization).filter(Organization.name == org.name).first():
+        raise HTTPException(status_code=400, detail="Organization already exists")
+    organization = Organization(name=org.name)
+    db.add(organization)
+    db.commit()
+    db.refresh(organization)
+    member = OrganizationUser(user_id=current_user.id, organization_id=organization.id, role="owner")
+    db.add(member)
+    db.commit()
+    return organization
+
+@router.get("/", response_model=list[OrganizationRead])
+def list_orgs(db: Session = Depends(get_db), current_user=Depends(get_current_user)):
+    memberships = db.query(OrganizationUser).filter_by(user_id=current_user.id).all()
+    return [m.organization for m in memberships]

--- a/app/routes/project.py
+++ b/app/routes/project.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from app.models import Project, ProjectUser, OrganizationUser
+from app.schemas import ProjectCreate, ProjectRead
+from app.utils.deps import get_db, get_current_user
+
+router = APIRouter(prefix="/projects")
+
+@router.post("/", response_model=ProjectRead)
+def create_project(project: ProjectCreate, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
+    # check if user is member of organization
+    membership = db.query(OrganizationUser).filter_by(user_id=current_user.id, organization_id=project.organization_id).first()
+    if not membership or membership.role not in ["owner", "admin"]:
+        raise HTTPException(status_code=403, detail="Not enough permissions")
+    proj = Project(name=project.name, organization_id=project.organization_id)
+    db.add(proj)
+    db.commit()
+    db.refresh(proj)
+    member = ProjectUser(user_id=current_user.id, project_id=proj.id, role="owner")
+    db.add(member)
+    db.commit()
+    return proj
+
+@router.get("/organization/{org_id}", response_model=list[ProjectRead])
+def list_projects(org_id: int, db: Session = Depends(get_db), current_user=Depends(get_current_user)):
+    membership = db.query(OrganizationUser).filter_by(user_id=current_user.id, organization_id=org_id).first()
+    if not membership:
+        raise HTTPException(status_code=403, detail="Not member of organization")
+    projects = db.query(Project).filter_by(organization_id=org_id).all()
+    return projects

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,4 @@
+from .user import UserCreate, UserRead
+from .token import Token
+from .organization import OrganizationCreate, OrganizationRead
+from .project import ProjectCreate, ProjectRead

--- a/app/schemas/organization.py
+++ b/app/schemas/organization.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+class OrganizationCreate(BaseModel):
+    name: str
+
+class OrganizationRead(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/project.py
+++ b/app/schemas/project.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+class ProjectCreate(BaseModel):
+    name: str
+    organization_id: int
+
+class ProjectRead(BaseModel):
+    id: int
+    name: str
+    organization_id: int
+
+    class Config:
+        orm_mode = True

--- a/app/schemas/token.py
+++ b/app/schemas/token.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+class UserCreate(BaseModel):
+    username: str
+    email: str
+    password: str
+
+class UserRead(BaseModel):
+    id: int
+    username: str
+    email: str
+
+    class Config:
+        orm_mode = True

--- a/app/utils/deps.py
+++ b/app/utils/deps.py
@@ -1,0 +1,36 @@
+from app.database import SessionLocal
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt, JWTError
+from app.models import User
+from .security import SECRET_KEY, ALGORITHM
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/login")
+
+
+def get_current_user(token: str = Depends(oauth2_scheme), db: SessionLocal = Depends(get_db)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: str = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = db.query(User).get(int(user_id))
+    if user is None:
+        raise credentials_exception
+    return user

--- a/app/utils/security.py
+++ b/app/utils/security.py
@@ -1,0 +1,22 @@
+from passlib.context import CryptContext
+from jose import jwt
+from datetime import datetime, timedelta
+import os
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+SECRET_KEY = os.getenv("SECRET_KEY", "secret")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+
+def create_access_token(data: dict, expires_delta: timedelta | None = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+SQLAlchemy
+PyMySQL
+python-jose
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- build Jira-like API with FastAPI
- add Dockerfile and requirements
- implement JWT auth with registration and login
- allow organizations and projects with roles
- document usage in README

## Testing
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_683fb795c550832f9c95b431bc202db8